### PR TITLE
Homebrew tap with the gsl@1 formulae supporting different macOS versions

### DIFF
--- a/Formula/gsl@1.rb
+++ b/Formula/gsl@1.rb
@@ -1,0 +1,19 @@
+class GslAT1 < Formula
+  desc "Numerical library for C and C++"
+  homepage "https://www.gnu.org/software/gsl/"
+  url "https://ftp.gnu.org/gnu/gsl/gsl-1.16.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gsl/gsl-1.16.tar.gz"
+  sha256 "73bc2f51b90d2a780e6d266d43e487b3dbd78945dd0b04b14ca5980fe28d2f53"
+
+  keg_only :versioned_formula
+
+  def install
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make" # A GNU tool which doesn't support just make install! Shameful!
+    system "make", "install"
+  end
+
+  test do
+    system bin/"gsl-randist", "0", "20", "cauchy", "30"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# homebrew-formulae
+# Homebrew Formulae
+
+[Homebrew][1] formulae for our packages.
+
+
+## Usage
+
+```shell
+$ brew tap mydrive/formulae
+$ brew install <formula>
+```
+
+To update the brew packages, use brew update first:
+
+```shell
+$ brew update
+$ brew upgrade mydrive
+```
+
+
+## Available Formulae
+
+- gsl@1 ported from the [removed formula][2]
+
+
+
+[1]: http://brew.sh/
+[2]: https://github.com/Homebrew/homebrew-core/blob/dbd1a4c0ff2712bbd53ac7f5642f107ff305238f/Formula/gsl%401.rb


### PR DESCRIPTION
### Description of the change

GSL version 1.x package is no longer available to be installed in a Mac via Homebrew
https://github.com/Homebrew/homebrew-core/pull/23083